### PR TITLE
Remove references to Portuguese

### DIFF
--- a/lists/br/index.html
+++ b/lists/br/index.html
@@ -1,22 +1,22 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="description" content="The list of Brazilian Portuguese speaking pixel artists">
+    <meta name="description" content="The list of Brazilian speaking pixel artists">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="index, follow">
-    <meta name="twitter:title" content="Brazilian Portuguese speaking pixel artists list">
-    <meta name="twitter:description" content="Hello everyone! This is a list of Brazilian Portuguese speaking pixel artists. Data is updated daily">
+    <meta name="twitter:title" content="Brazilian speaking pixel artists list">
+    <meta name="twitter:description" content="Hello everyone! This is a list of Brazilian speaking pixel artists. Data is updated daily">
     <meta name="twitter:image" content="https://pbs.twimg.com/profile_banners/1228256088748961793/1582842006/1500x500">
     <meta name="twitter:site" content="@84Aleha">
     <meta name="twitter:creator" content="@84Aleha">
     <meta name="twitter:card" content="summary_large_image">
 
-    <meta property="og:title" content="Brazilian Portuguese speaking pixel artists list">
-    <meta property="og:description" content="Hello everyone! This is a list of Brazilian Portuguese speaking pixel artists. Data is updated daily">
+    <meta property="og:title" content="Brazilian speaking pixel artists list">
+    <meta property="og:description" content="Hello everyone! This is a list of Brazilian speaking pixel artists. Data is updated daily">
     <meta property="og:image" content="https://pbs.twimg.com/profile_banners/1228256088748961793/1582842006/1500x500">
     <meta property="og:url" content="https://aleha84.github.io/pacommunity/lists/br/">
 
-    <title>Brazilian Portuguese speaking pixel artists list</title>
+    <title>Brazilian speaking pixel artists list</title>
 
     <script src="../../external/uPlot.iife.min.js"></script>
     <script src="../../common/scripts.js?v=5.2"></script>
@@ -62,7 +62,7 @@
         <div id='parent'>
           <div class="pageHeader">
             <h3>
-              Brazilian Portuguese speaking pixel artists list
+              Brazilian speaking pixel artists list
               <span class='quastion' onclick="helpShow()"><img width="16" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAMfElEQVR4Xr1baZRUxRX+br0eBhEVZAhBmH71uptF1IjBiKAox0RzopEYF9y3qHhwS9xwTUziwlFUUKMx0XjULCISTIKaI5wYoyh4FIwYkeV1v/d6BhMEBUHW6Vc3p3pmsPv1672H+jdTdbfvVd26de9tQg8P0zQHG8A4Ag5jYCQBUjEPAtAPjOaseMJOAJsE0ToGXAI+BvC+T7TYdd3/9aSK1BPME6Y5TkGcTuyfBBIj6pFBPlYy0cvC4BfWuO479fAKo20YALFYbD/y/UtBdDkYwxqtaJYfq1VE9Fs0NT1p2/bmRsioG4BoNNq/iYwbFPtXCxL7NEKpcjyUUpuFoIfZMO5PpVJflFtfar4eAERMysuZcacABtSjRK20CrxBMN2WTLtP6P1RC5+aAIgNjQ1ThnraAMZXI1SB1wtglXZ0ArSFwV92+kDqq8D7EISloEYIUEs1fAFeREpdZLe1Jauj07KrHImodZ4ifpyAvSsg/a8izBfAa4rodcdx1lVAAynl1w1gIpiPg+JJEELfGiWHAn9JRFNSrvtcubW589UAIBJR+QATflJOFwbPI6LfJV13IQC/GoVC1hox0/wuKboEAqcAEKWRoAeSbc40AKoSuRUBMGrUqF47t2ybDYEflmCqwHiWI2J6KpVaXYnwatdIKUcazLcCdF725BQZDH6hf0vLuUuXLu0oJ6MsAF3G/wUC3yvOjN9jZUxNtaXeKyewEfMJKY/0M3hMGDisGD8Cv7RfS8up5UAoB4CIt8q5Jb68YsYvUmn3rkq3XCMA6OJhxE3z5wDdWuxY6J2Q8rwzS90QJQGISzkLjB+HKZ29goDJSc/7ZwONqpqVFbWOF8TPA+gfTswzkp6nfULoKApAPGpdAOJnQqmUn1aRyAmO46yqWuMeIEhEowcpEq8SMKSIlWcnXXd22FwoALFYbDh8tSz0qlNwSUUm2Gvt9h6wpWaWsVgsypnMIkGiNchEsdrSBIxenU6ngnNhAOhz/xYEjixgBF5PvnFUqj21plpNvzFo0N5be/ceS0SHMnMMRF8j5j4+s2+Q+Bxgm4El/Vpa3iznuIrJHmaaB2ZAb4ZHprwo6XnHBP1BAQAJ07yCQY8WGK9Uh2GIY2zXXVKp8droL3v3PlMQneX7aqIQoqkcrfYtBtGjfbZvn7F83bqt5dYH54dZ1jFK8WsAjAJapinJtKPD5t0jDwD9sOlFQn+J/Qu3Cl9ve96DlSoUM81TCfRkcedUmpMPJCOsfmCn0x9VKrN7XcI0b2XQ3SE7eAMZRiL3AZUHQCwq7yHCLYUC6R9Jz/lONYrETaljgjHV0IQduV7A2FWe51TJh+JS/guMCQUfkvBL23Xv6P7/bgCklP2IuU2A+uYSKaV2UVPkkGqju4Qpn2Lg4iKK65fbJii1C0LsC2CvYgYyqzdS6fSxVQKAeGv8YCUy7wtQJGDPZqO5V2t3PmE3AHHTuhHg+woEEe5Luu5N1SpgWdYIZPwPvzr3/B8As5UQCzs6Oj5sb2/f3s1T3zpCqR/5vrouzE8wiwmpdGpRtToUi2MIXx3nbgDIMs3VApQICNlGTRFp2/b6aoXr9ZZlHSF8nsgsXqskTI6Z5kkEeikoi0EPpjzn+mp10PlIodgRQnTmHrsHq1XJdHqk/jMLQNw0xwP0VsjXfzjpuqGRYLXKVLo+IeUCZhyfu54IC23XPaFSHrnrEqZ8jIGpQVpBOFLnGLMAJKJyZtgzl1gdZKfTK2oRXCtN3LTuAvi2vA8GLEt5bk0OdZiUoxXj/UJ9+P6k592YBcAyzTUh239p0nMPr9WQWunCAIDCkmSbO65mnlIuB+OQAKgrUp57ECWGJIZyJNNWwJxxUzLtFjrFWrWokC4u5V/BmJS7XLF63kmnz6qQRcGyuGndDvCdwQmfMJgSUesMJp5TCIA6PJlOL61VaC108Xi8Ve3qWBN0WgS+0va8x2rhWcrHMfg0Cg1+FDYl21yd6a0orVSrYrl0UsreBrAgGLzoh0yHUrK9vf3zWuVMxMSIZzobgzGO3hUUM+WLhGyu7atBeDPpuvrhsEdG9s3Q3DyPSIR4epqW9JwZ9SoSM80lBBqb7wd4rt4B7xNhdL4AfjLpeZfVK7QS+hGtrQdkhPG38LCZXk56jvYHde9ES8pnBOOCgE5LKW7KTwAMzkOGcXMq7d5biQH1rOmKP+YG5WuezGrBLqVOyY0Y65EVi8qfEeEXec4V3K4B2BaMxZkwNeW6j9cjsBxtotWa5MOfUxClZa3H0/0GDphSa14gTHY8Kq8B4aH8I4CtGgCdt8/LtRPT+Xba+UM5I2qdT0h5rO+rBUKIXoEvkjGIptmuO7NW3sXoYlJeTIynAvN+KAAgFM2h1atYIpHYlzsyKwu2vcImCD4t6Xk6mdHwoStaTPz7MAAKjgCBLrM9RyczGj4SUt7CjHvyvzw+g6BvO47zQcMFdjGMSTmVGMFYYlu4EyRcm3LdWT2hjDVULgsWNBTTCU7a0WW0HhvxqJwGQp5jZ2Bt+DWosvW1GxqtTVdAsj03ScHgd1KeV5CAbbTsuGk+AtBVASe4LDwQQvb+/X6jlbAsa5BQnN/zQ9gjT+7QZzboz5SIyulMuDmAjJPy3FijAdBtNNyRWZ+b9SGmyXbaeaHRsoL8LNPU6b6h+f/nu/RjaDJ3lpbyBmUirT1R/EhIORFdERkTFhSr2DQSkOHRaMwnUdA8weDTSVdUyFdeAQBMF9hpJ3htNFKvPcYrYVqXMjivHqCFZ8AHZBMi0pS2AcTzj0G2sjp5j2nZg4LCcgxQ+DjZ5o7qzAlK+RAY1+TpoLDDNzDYdd1NPahbj7MefsDwlg5jxycF2eaum64zJdZqTRCC3whqw4QrUq7760ZqqRXK9Np1vGDuz4DT6lkLX8frmUbKyOUV9gbQ8wQeb3ve4py0uLQFkOf5dXnK9Vzd6Vlvn09WJ+0Afeb5+YkJXt6UyRy3cu3azxoNwpgxY5o2rVu/BoYw8z081iRdd3gnEF0jJuXNxJhesAvA56Y870+NUC5umh8CdHChDMxMee51jZCRy6PIA0ibvTvJshsAXRiNkGgr6AlQcHdyZlS97/LO8vhe2b7AwsHvJT3vW40EYNTAUX139Nm2Mtg0oVNsFIm0dhdI84qjcSnvBSOknYTuTnrO7fUo2NlLrIo4VF6e9LxD6+EfpI23WvdDcEg1Kd+WPACGDh26f7MRsYMlbaVUByFyVKot9W49SoZHY4AiPOu47oX18M53fNGjdGNmQWEUvIGJhuXebAUNEvGodTWIHw45pw4McVg9zclhAYnu8DSYxzaqAjVyyJABOyORfxeGvUBYpiu0RSYRjS5mEkcUfBFWr/YbOPDkelJVMdM8UUCcw+y3MBk2CzzSqGarbE/j1m1/B3BcUHfFWOyk3aODCdbQJqnOjkwsC6vbE+iPtuecX2t3dqO2eQgfEZfyOTAKolcGtsIXh4X1NhVtkyt+hXSeWdOVl/RkAFMNUPq+/+LTz55mgXPC6ErlOEs2SsZM61e6LBV+c+GV5u19zlyxfkWRq60aE2pfq3OMyGTmBkvq3RyJMctOu9cWk1CuVdaISfkiMU4OB0GtUoYx2XGc5bWbUDtlwjS/mQHNCT7kdnNUmJdsc88oVVgpBwASiUQzMpn5xRCGwg4Q7ug3cMDMepxjNTBoZ7dr27brfV/dEVpX0MxYvdrct++kFStW7CrFuywAmliDwJnMnGDZOpcxAyuEoGttx1lQjTHVrs3eIj49wAayLS6hQ+FFao6cbdu2/jleyVERAF0cdHf2rGBisYA74V0wT2/1rPmNcpLayW3csGESgXQLX8lOka4zryPAiuqJ1QCQtTUu5UVg6E7SPiWh9dWniIjZBMzr1afP4nJbMcir6+iN85lPBXCWAA0sJU9fdYJparVZrKoB0EroOCGi1DOhwVK4ltsBehvEHxHzKgW4YGMzG7xFLyef9gH5+wpAMtEIMPSLUbfEFO0fzBOjsISbxIXV9jJmZZc7IyXmRTxqXQliXXEt0qtfB/cKSAnQTdY/tT1PF3Ir2vJBtvUAkOWlY+9MU9ONinFVhb8kq8C00kuyvxBjeiQDNSOdTm+sh2HdAHQLz+YThNA/m51CgFWPUsVodYZKMJ5QAr9pVK6yYQDkKE1Wq3W0MPh0xXxiSPtdldjwamJ6haHmJtPptxv9BukJAPIM1J1f8P3xpDDahzpQEFlQPEgB/bv7A5RSOwXERoK/TgnDAeNjEviAOiJv9URxJlfB/wOcsTQMHSkYdgAAAABJRU5ErkJggg==" /></span>
             </h3>
             <div class="otherLists">
@@ -107,12 +107,12 @@
           <div class='help'>
             <div class='langSwitch'><span class="br">PTBR</span><span class='separator'>|</span><span class="en">EN</span></div>
             <div class='en'>
-              <p>Hello everyone! This is a list of Brazilian Portuguese speaking pixel artists. I created this because I wanted to join information together and share it with everyone around, and also to code a little. Data is updated daily (for now manually)</p>
+              <p>Hello everyone! This is a list of Brazilian speaking pixel artists. I created this because I wanted to join information together and share it with everyone around, and also to code a little. Data is updated daily (for now manually)</p>
               <p>I plan to support and develop this page with pure enthusiasm: searching for new artists, add new features to the page and automate data updates. Also, if there is interest, I will be happy to create similar lists for other languages.</p>
               <p>If you know pixel artists I haven't mentioned on this list, or if you find a bug/mistake, then let me know. Bookmark this page to your browser and share or retweet to let more people know about these wonderful and talented people</p>
             </div>
             <div class='br'>
-              <p>Oi gente! Esta é uma lista de artistas pixel falantes de Português Brasileiro (por enquanto, todos brasileiros). Eu criei isso porque eu queria juntar informações e compartilhá-la, e também porque queria programar um pouco. Os dados são atualizados diariamente (por enquanto manualmente).</p>
+              <p>Oi gente! Esta é uma lista de artistas pixel falantes de Brasileiro (por enquanto, todos brasileiros). Eu criei isso porque eu queria juntar informações e compartilhá-la, e também porque queria programar um pouco. Os dados são atualizados diariamente (por enquanto manualmente).</p>
               <p>Pretendo dar suporte e desenvolver esta página com puro entusiasmo: procurar novos artistas, adicionar novos recursos à página e automatizar atualizações de dados. Além disso, se houver interesse, ficarei feliz em criar listas semelhantes para outros idiomas.</p>
               <p>Se você conhece artistas que não estão nessa lista, ou se você encontrar um bug/erro, me avise (no caso dos artistas pode avisar a maruki). Adicione esta página aos seus favoritos e compartilhe ou dê RT para que mais pessoas saibam sobre esses artistas maravilhosos e talentosos</p>
             </div>


### PR DESCRIPTION
This removes all references to "Portuguese" and "Português".

Our language is our own and we need not reference Portugal.

We should take advantage that language is alive and ever changing to make our mark and break ties with a past of oppression, creating new meaning for things we hold dear. I know this is a silly change, but that's exactly why I think it's worth it.